### PR TITLE
Issue #77: Bump dot-cli to v3.11.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
-        "dotkernel/dot-cli": "^3.9",
+        "dotkernel/dot-cli": "^3.11.1",
         "dotkernel/dot-dependency-injection": "^1.2",
         "dotkernel/dot-errorhandler": "4.2.1",
         "laminas/laminas-component-installer": "^3.5",

--- a/src/Swoole/Delegators/TCPServerDelegator.php
+++ b/src/Swoole/Delegators/TCPServerDelegator.php
@@ -11,7 +11,6 @@ use Queue\App\Message\Message;
 use Queue\Swoole\Command\GetFailedMessagesCommand;
 use Queue\Swoole\Command\GetProcessedMessagesCommand;
 use Queue\Swoole\Command\GetQueuedMessagesCommand;
-use Queue\Swoole\Exception\RuntimeException;
 use Swoole\Server as TCPSwooleServer;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -24,8 +23,6 @@ use function array_merge;
 use function array_shift;
 use function explode;
 use function ltrim;
-use function method_exists;
-use function sprintf;
 use function str_starts_with;
 use function trim;
 
@@ -66,15 +63,7 @@ class TCPServerDelegator
                 $commandClass    = $commandMap[$commandName];
                 $application     = new Application();
                 $commandInstance = $container->get($commandClass);
-                if (method_exists($application, 'addCommand')) {
-                    $application->addCommand($commandInstance);
-                } elseif (method_exists($application, 'add')) {
-                    $application->add($commandInstance);
-                } else {
-                    throw new RuntimeException(
-                        sprintf('%s contains no "add" or "addCommand" method.', $application::class)
-                    );
-                }
+                $application->addCommand($commandInstance);
 
                 $parsedOptions = [];
                 foreach ($args as $arg) {


### PR DESCRIPTION
Updated `dot-cli` to `v3.11.1` which requires `laminas-cli` `v1.15.0`. `laminas-cli` requires `symfony/console` `^7.4`, making the [previous](https://github.com/dotkernel/queue/pull/73/changes) compatibility workaround for `add()`/`addCommand()` no longer necessary. Reverted those changes.