### PR TITLE
Issue #93: Bump php to 8.5.0

### DIFF
--- a/.laminas-ci/pre-install.sh
+++ b/.laminas-ci/pre-install.sh
@@ -1,1 +1,0 @@
-apt-get update --allow-releaseinfo-change || true

--- a/.laminas-ci/pre-install.sh
+++ b/.laminas-ci/pre-install.sh
@@ -1,0 +1,1 @@
+apt-get update --allow-releaseinfo-change || true

--- a/composer.json
+++ b/composer.json
@@ -43,10 +43,10 @@
         }
     },
     "require": {
-        "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "dotkernel/dot-cli": "^3.11.1",
         "dotkernel/dot-dependency-injection": "^1.2",
-        "dotkernel/dot-errorhandler": "4.2.1",
+        "dotkernel/dot-errorhandler": "4.4.2",
         "laminas/laminas-component-installer": "^3.5",
         "laminas/laminas-config-aggregator": "^1.18",
         "mezzio/mezzio": "^3.20",


### PR DESCRIPTION
- Upgraded the available PHP version to `8.5.0`
- Updated `dot-errorhandler` that was blocking the upgrade, existing version was not compatible with PHP `8.5.0`